### PR TITLE
send_mess() uses 'const char *'

### DIFF
--- a/imsApp/src/drvIM483PL.cc
+++ b/imsApp/src/drvIM483PL.cc
@@ -90,14 +90,14 @@ static inline void Debug(int level, const char *format, ...) {
 
 /* --- Local data. --- */
 int IM483PL_num_cards = 0;
-static char *IM483PL_axis[] = {"A", "B", "C", "D", "E", "F", "G", "H"};
+static const char *IM483PL_axis[] = {"A", "B", "C", "D", "E", "F", "G", "H"};
 
 /* Local data required for every driver; see "motordrvComCode.h" */
 #include    "motordrvComCode.h"
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int set_status(int, int);
 static long report(int);
 static long init();
@@ -375,7 +375,7 @@ exit:
 /* send a message to the IM483PL board           */
 /* send_mess()                               */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     char local_buff[MAX_MSG_SIZE];
     struct IM483controller *cntrl;

--- a/imsApp/src/drvIM483SM.cc
+++ b/imsApp/src/drvIM483SM.cc
@@ -94,7 +94,7 @@ int IM483SM_num_cards = 0;
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int set_status(int, int);
 static long report(int);
 static long init();
@@ -238,7 +238,7 @@ static int set_status(int card, int signal)
     nodeptr = motor_info->motor_motion;
     status.All = motor_info->status.All;
 
-    send_mess(card, "^", (char*) NULL);
+    send_mess(card, "^", NULL);
     rtn_state = recv_mess(card, buff, 1);
     if (rtn_state > 0)
     {
@@ -273,7 +273,7 @@ static int set_status(int card, int signal)
      * Skip to substring for this motor, convert to double
      */
 
-    send_mess(card, "Z 0", (char*) NULL);
+    send_mess(card, "Z 0", NULL);
     recv_mess(card, buff, 1);
 
     motorData = atof(&buff[5]);
@@ -295,7 +295,7 @@ static int set_status(int card, int signal)
 
     plusdir = (status.Bits.RA_DIRECTION) ? true : false;
 
-    send_mess(card, "] 0", (char*) NULL);
+    send_mess(card, "] 0", NULL);
     recv_mess(card, buff, 1);
     rtnval = atoi(&buff[5]);
 
@@ -318,7 +318,7 @@ static int set_status(int card, int signal)
     else
         status.Bits.RA_MINUS_LS = 0;
 
-    send_mess(card, "] 1", (char*) NULL);
+    send_mess(card, "] 1", NULL);
     recv_mess(card, buff, 1);
     rtnval = buff[5];
 
@@ -336,7 +336,7 @@ static int set_status(int card, int signal)
         motor_info->encoder_position = 0;
     else
     {
-        send_mess(card, "z 0", (char*) NULL);
+        send_mess(card, "z 0", NULL);
         recv_mess(card, buff, 1);
         motorData = atof(&buff[5]);
         motor_info->encoder_position = (epicsInt32) motorData;
@@ -359,7 +359,7 @@ static int set_status(int card, int signal)
         nodeptr->postmsgptr != 0)
     {
         strcpy(buff, nodeptr->postmsgptr);
-        send_mess(card, buff, (char*) NULL);
+        send_mess(card, buff, NULL);
         nodeptr->postmsgptr = NULL;
     }
 
@@ -373,7 +373,7 @@ exit:
 /* send a message to the IM483SM board           */
 /* send_mess()                               */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     struct IM483controller *cntrl;
     int size;
@@ -551,9 +551,9 @@ static int motor_init()
                 /* flush any junk at input port - should not be any data available */
                 pasynOctetSyncIO->flush(cntrl->pasynUser);
 
-                send_mess(card_index, "\003", (char*) NULL); /* Reset device. */
+                send_mess(card_index, "\003", NULL); /* Reset device. */
                 epicsThreadSleep(1.0);
-                send_mess(card_index, " ", (char*) NULL);
+                send_mess(card_index, " ", NULL);
 
                 /* Save controller identification message. */
                 src = buff;

--- a/imsApp/src/drvMDrive.cc
+++ b/imsApp/src/drvMDrive.cc
@@ -104,14 +104,14 @@ static inline void Debug(int level, const char *format, ...) {
 
 /* --- Local data. --- */
 int MDrive_num_cards = 0;
-static const char* const MDrive_axis[] = {"1", "2", "3", "4", "5", "6", "7", "8"};
+static const char* MDrive_axis[] = {"1", "2", "3", "4", "5", "6", "7", "8"};
 
 /* Local data required for every driver; see "motordrvComCode.h" */
 #include    "motordrvComCode.h"
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, const char *const);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int set_status(int, int);
 static long report(int);
 static long init();
@@ -135,13 +135,13 @@ struct driver_table MDrive_access =
     &motor_state,
     &total_cards,
     &any_motor_in_motion,
-    (RTN_STATUS (*)(int, const char*, char*)) send_mess,
+    send_mess,
     recv_mess,
     set_status,
     query_done,
     NULL,
     &initialized,
-    (char **) MDrive_axis
+    MDrive_axis
 };
 
 struct drvMDrive_drvet
@@ -415,7 +415,7 @@ exit:
 /* send a message to the MDrive board                */
 /* send_mess()                                       */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, const char *const name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     char local_buff[MAX_MSG_SIZE];
     struct IM483controller *cntrl;


### PR DESCRIPTION
The 3rd parameter in send_mess(), "name" can and should
be a 'const char *' instead of just 'char *'.
Modern compilers complain here, so that the signature now
gets the const.

This is a minimal part of a series from Dirk Zimoch,
more warnings can be removed here and there.